### PR TITLE
fix: 修复 Game.js gameLoop 首次调用时间计算问题 (#43)

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -45,7 +45,7 @@ export class Game {
     if (this.status === 'start') {
       this.status = 'playing';
       this.lastTime = performance.now();
-      this.gameLoop();
+      this.gameLoop(this.lastTime);
     }
   }
 
@@ -53,7 +53,7 @@ export class Game {
    * 游戏主循环
    * @param {number} timestamp - 时间戳
    */
-  gameLoop(timestamp = 0) {
+  gameLoop(timestamp) {
     if (this.status !== 'playing') {
       return;
     }


### PR DESCRIPTION
## 变更说明

修复了 gameLoop 方法首次调用时 timestamp 默认值为 0 导致 deltaTime 计算不准确的问题。

### 修改内容
- 移除 gameLoop(timestamp = 0) 中的默认值 0
- 在 start() 方法中调用 gameLoop 时传入 this.lastTime（已通过 performance.now() 初始化）

### 影响范围
- 仅影响游戏启动时的逻辑严谨性
- 修复后代码更规范，避免潜在的时间计算问题

## 关联 Issue
Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved game loop initialization to ensure proper timestamp handling on each update cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->