### PR TITLE
refactor: 分离 Renderer 到独立文件并保持向后兼容 (#57)

### DIFF
--- a/js/Renderer.js
+++ b/js/Renderer.js
@@ -217,3 +217,6 @@ export class Renderer {
     }
   }
 }
+
+// 导出为全局变量保持向后兼容
+window.Renderer = Renderer;


### PR DESCRIPTION
## 变更说明

将 Renderer 类完全分离到独立文件 Renderer.js，并添加 ES6 模块导出和向后兼容的 window 全局导出。

## 变更内容

- 确认 Renderer 类已完全移至 Renderer.js（之前已完成）
- 添加 `window.Renderer = Renderer` 保持向后兼容

## 关联 Issue

Closes #57

## 测试说明

- 确认游戏正常运行
- 确认渲染功能正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backward compatibility by making the Renderer class globally accessible through the window object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->